### PR TITLE
feat: Add grafbase as a federation-v1 gateway

### DIFF
--- a/.github/workflows/federation-v1.workflow.yaml
+++ b/.github/workflows/federation-v1.workflow.yaml
@@ -37,6 +37,7 @@ jobs:
           # - mesh-bun
           - mesh-supergraph
           - mesh-supergraph-bun
+          - grafbase
     uses: ./.github/workflows/benchmark.template.yaml
     with:
       gateway: ${{ matrix.directory }}
@@ -75,6 +76,7 @@ jobs:
           # - mesh-bun
           - mesh-supergraph
           - mesh-supergraph-bun
+          - grafbase
     uses: ./.github/workflows/benchmark.template.yaml
     with:
       gateway: ${{ matrix.directory }}
@@ -114,6 +116,7 @@ jobs:
           # - mesh-bun
           - mesh-supergraph
           - mesh-supergraph-bun
+          - grafbase
     uses: ./.github/workflows/benchmark.template.yaml
     with:
       gateway: ${{ matrix.directory }}
@@ -153,6 +156,7 @@ jobs:
           # - mesh-bun
           - mesh-supergraph
           - mesh-supergraph-bun
+          - grafbase
     uses: ./.github/workflows/benchmark.template.yaml
     with:
       gateway: ${{ matrix.directory }}
@@ -173,3 +177,4 @@ jobs:
       scenarioName: ramping-vus
       scenarioDir: ramping-vus
       baseDir: federation-v1
+

--- a/federation-v1/gateways/apollo-router/config.yaml
+++ b/federation-v1/gateways/apollo-router/config.yaml
@@ -4,3 +4,6 @@ supergraph:
 traffic_shaping:
   all:
     deduplicate_query: true
+health_check:
+  listen: 0.0.0.0:8088
+  enabled: true

--- a/federation-v1/gateways/apollo-router/docker-compose.yaml
+++ b/federation-v1/gateways/apollo-router/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   gateway:
-    image: ghcr.io/apollographql/router:v1.34.0-alpha.1
+    image: ghcr.io/apollographql/router:v1.38.0
     container_name: gateway
     networks:
       - test
@@ -27,7 +27,7 @@ services:
         source: federation-v1/gateways/apollo-router/config.yaml
         target: /dist/config/router.yaml
     healthcheck:
-        test: ["CMD", "/usr/lib/apt/apt-helper", "download-file", "http://127.0.0.1:8088/health?ready", "temp"]
+        test: ["CMD", "/usr/lib/apt/apt-helper", "download-file", "http://127.0.0.1:8088/health?ready", "/tmp/health"]
         interval: 3s
         timeout: 5s
         retries: 10

--- a/federation-v1/gateways/cosmo/Dockerfile
+++ b/federation-v1/gateways/cosmo/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --no-cache add curl
 WORKDIR /home/gw
 COPY config.json ./
 
-ENV ROUTER_VERSION=0.43.3
+ENV ROUTER_VERSION=0.57.0
 
 RUN curl -L https://github.com/wundergraph/cosmo/releases/download/router%40${ROUTER_VERSION}/router-router@${ROUTER_VERSION}-linux-$(uname -m | sed s:aarch:arm:| sed s:x86_:amd:).tar.gz | gunzip -dc | tar x && mv router /usr/local/bin
 

--- a/federation-v1/gateways/grafbase/Dockerfile
+++ b/federation-v1/gateways/grafbase/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/grafbase/grafbase:latest
+
+COPY package.json package-lock.json grafbase.config.ts supergraph.graphql ./
+
+RUN npm ci
+
+EXPOSE 4000
+
+CMD ["start", "--federated-graph-schema", "supergraph.graphql", "--port", "4000"]

--- a/federation-v1/gateways/grafbase/Dockerfile
+++ b/federation-v1/gateways/grafbase/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/grafbase/grafbase:latest
+FROM ghcr.io/grafbase/grafbase:0.56.0
 
 COPY package.json package-lock.json grafbase.config.ts supergraph.graphql ./
 

--- a/federation-v1/gateways/grafbase/docker-compose.yaml
+++ b/federation-v1/gateways/grafbase/docker-compose.yaml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+services:
+  gateway:
+    image: gateway/grafbase
+    container_name: gateway
+    build:
+      context: ${BASE_DIR:-.}/../../gateways/grafbase
+      dockerfile: ./Dockerfile
+    networks:
+      - test
+    ports:
+      - "0.0.0.0:4000:4000"
+    depends_on:
+      accounts: 
+        condition: service_healthy
+      inventory:
+        condition: service_healthy
+      products:
+        condition: service_healthy
+      reviews:
+        condition: service_healthy
+    healthcheck:
+        test: ["CMD", "curl", "-f", "http://127.0.0.1:4000/graphql"]
+        interval: 3s
+        timeout: 5s
+        retries: 10
+    deploy:
+      resources:
+        limits:
+          cpus: ${CPU_LIMIT:-1}
+          memory: ${MEM_LIMIT:-1gb}
+networks:
+  test:
+    name: test

--- a/federation-v1/gateways/grafbase/grafbase.config.ts
+++ b/federation-v1/gateways/grafbase/grafbase.config.ts
@@ -1,0 +1,6 @@
+import { config, graph } from '@grafbase/sdk'
+
+export default config({
+  graph: graph.Federated(),
+})
+

--- a/federation-v1/gateways/grafbase/package-lock.json
+++ b/federation-v1/gateways/grafbase/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "federated",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "federated",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@grafbase/sdk": "~0.15.0"
+      }
+    },
+    "node_modules/@grafbase/sdk": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.15.0.tgz",
+      "integrity": "sha512-Nh2rJQzXtT7gbzTBLfpuSDhp3ONVOyI70fSkbLht1IC4QgSQAt0AsrFnneoa6U45YavwCXtKR/oO+XQv48wilw==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "^16.1.4",
+        "type-fest": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=16.13.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/federation-v1/gateways/grafbase/package-lock.json
+++ b/federation-v1/gateways/grafbase/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@grafbase/sdk": "~0.15.0"
+        "@grafbase/sdk": "~0.17.0"
       }
     },
     "node_modules/@grafbase/sdk": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.15.0.tgz",
-      "integrity": "sha512-Nh2rJQzXtT7gbzTBLfpuSDhp3ONVOyI70fSkbLht1IC4QgSQAt0AsrFnneoa6U45YavwCXtKR/oO+XQv48wilw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@grafbase/sdk/-/sdk-0.17.0.tgz",
+      "integrity": "sha512-3XJAwGFIeaU4TcoTzxjbRnyBPBVQ0jv+/lcrF8y0UM0j+95JfOgnvg7B3CVam9E+vqP1Env02v3QRc/vqwMmPA==",
       "dev": true,
       "dependencies": {
         "dotenv": "^16.1.4",
-        "type-fest": "^3.9.0"
+        "type-fest": "^4.0.0"
       },
       "engines": {
         "node": ">=16.13.0"
@@ -38,12 +38,12 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.2.tgz",
+      "integrity": "sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==",
       "dev": true,
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/federation-v1/gateways/grafbase/package.json
+++ b/federation-v1/gateways/grafbase/package.json
@@ -1,0 +1,16 @@
+{
+  "author": "",
+  "description": "",
+  "devDependencies": {
+    "@grafbase/sdk": "~0.15.0"
+  },
+  "keywords": [],
+  "license": "ISC",
+  "main": "index.js",
+  "name": "federated",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "version": "1.0.0"
+}
+

--- a/federation-v1/gateways/grafbase/package.json
+++ b/federation-v1/gateways/grafbase/package.json
@@ -2,7 +2,7 @@
   "author": "",
   "description": "",
   "devDependencies": {
-    "@grafbase/sdk": "~0.15.0"
+    "@grafbase/sdk": "~0.17.0"
   },
   "keywords": [],
   "license": "ISC",

--- a/federation-v1/gateways/grafbase/supergraph.graphql
+++ b/federation-v1/gateways/grafbase/supergraph.graphql
@@ -1,0 +1,89 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://accounts:4001/graphql")
+  INVENTORY @join__graph(name: "inventory", url: "http://inventory:4002/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://products:4003/graphql")
+  REVIEWS @join__graph(name: "reviews", url: "http://reviews:4004/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Product
+  @join__type(graph: INVENTORY, key: "upc")
+  @join__type(graph: PRODUCTS, key: "upc")
+  @join__type(graph: REVIEWS, key: "upc")
+{
+  upc: String!
+  weight: Int @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+  price: Int @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+  name: String @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}
+
+type Query
+  @join__type(graph: ACCOUNTS)
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS)
+{
+  me: User @join__field(graph: ACCOUNTS)
+  user(id: ID!): User @join__field(graph: ACCOUNTS)
+  users: [User] @join__field(graph: ACCOUNTS)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review
+  @join__type(graph: REVIEWS, key: "id")
+{
+  id: ID!
+  body: String
+  product: Product
+  author: User @join__field(graph: REVIEWS, provides: "username")
+}
+
+type User
+  @join__type(graph: ACCOUNTS, key: "id")
+  @join__type(graph: REVIEWS, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: ACCOUNTS)
+  username: String @join__field(graph: ACCOUNTS) @join__field(graph: REVIEWS, external: true)
+  birthday: Int @join__field(graph: ACCOUNTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}

--- a/federation-v1/gateways/mesh-bun/Dockerfile
+++ b/federation-v1/gateways/mesh-bun/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:latest
+FROM oven/bun:1.0.15
 
 COPY package.json ./
 COPY .meshrc.yaml ./

--- a/federation-v1/gateways/mesh-bun/Dockerfile
+++ b/federation-v1/gateways/mesh-bun/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.0.15
+FROM oven/bun:latest
 
 COPY package.json ./
 COPY .meshrc.yaml ./

--- a/federation-v1/gateways/mesh-supergraph-bun/Dockerfile
+++ b/federation-v1/gateways/mesh-supergraph-bun/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.0.15
+FROM oven/bun:latest
 
 COPY package.json ./
 COPY .meshrc.yaml ./

--- a/federation-v1/gateways/mesh-supergraph-bun/Dockerfile
+++ b/federation-v1/gateways/mesh-supergraph-bun/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:latest
+FROM oven/bun:1.0.26
 
 COPY package.json ./
 COPY .meshrc.yaml ./

--- a/federation-v1/scenarios/compose-supergraph.ts
+++ b/federation-v1/scenarios/compose-supergraph.ts
@@ -65,6 +65,7 @@ async function main() {
     } else {
         console.log("Got SDL:\n", supergraphSdl);
         writeFileSync(__dirname + '/../gateways/apollo-router/supergraph.graphql', supergraphSdl!);
+        writeFileSync(__dirname + '/../gateways/grafbase/supergraph.graphql', supergraphSdl!);
         writeFileSync(__dirname + '/../gateways/apollo-server/supergraph.graphql', supergraphSdl!);
         writeFileSync(__dirname + '/../gateways/apollo-server-node16/supergraph.graphql', supergraphSdl!);
         writeFileSync(__dirname + '/../gateways/mesh-supergraph/supergraph.graphql', supergraphSdl!);

--- a/federation-v1/scenarios/constant-vus-over-time/run.sh
+++ b/federation-v1/scenarios/constant-vus-over-time/run.sh
@@ -27,7 +27,7 @@ on_error(){
  
 trap 'on_error' ERR
 
-docker compose $COMPOSE_FLAGS up -d --wait --force-recreate
+docker compose $COMPOSE_FLAGS up -d --wait --force-recreate --build
 
 if [[ -z "${CI}" ]]; then
     trap "docker compose $COMPOSE_FLAGS down && exit 0" INT
@@ -37,7 +37,7 @@ export K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write
 export K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
 export START_TIME="$(date +%s)"
 
-k6 --out=experimental-prometheus-rw --out json=$OUT_DIR/k6_metrics.json run -e SUMMARY_PATH="$OUT_DIR" benchmark.k6.js
+k6 --out=experimental-prometheus-rw --summary-trend-stats="avg,min,med,p(90),p(99),p(99.9),p(99.99),max" --out json=$OUT_DIR/k6_metrics.json run -e SUMMARY_PATH="$OUT_DIR" benchmark.k6.js
 
 sleep 2
 

--- a/federation-v1/scenarios/ramping-vus/run.sh
+++ b/federation-v1/scenarios/ramping-vus/run.sh
@@ -27,7 +27,7 @@ on_error(){
  
 trap 'on_error' ERR
 
-docker compose $COMPOSE_FLAGS up -d --wait --force-recreate
+docker compose $COMPOSE_FLAGS up -d --wait --force-recreate --build
 
 if [[ -z "${CI}" ]]; then
     trap "docker compose $COMPOSE_FLAGS down && exit 0" INT
@@ -37,7 +37,7 @@ export K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write
 export K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
 export START_TIME="$(date +%s)"
 
-k6 --out=experimental-prometheus-rw --out json=$OUT_DIR/k6_metrics.json run -e SUMMARY_PATH="$OUT_DIR" benchmark.k6.js
+k6 --out=experimental-prometheus-rw --summary-trend-stats="avg,min,med,p(90),p(99),p(99.9),p(99.99),max" --out json=$OUT_DIR/k6_metrics.json run -e SUMMARY_PATH="$OUT_DIR" benchmark.k6.js
 
 sleep 2
 


### PR DESCRIPTION
Hello!

First of all, thank you for this repository it's well done and was a pleasure to work with. The goal of this PR is to add Grafbase (https://github.com/grafbase/grafbase/) as a gateway in the federation-v1 benchmarks.

I also took the liberty of updating `apollo-router` and `cosmo` to their latest versions and bun to `latest` for `mesh-bun` & `mesh-supergraph-bun`. I've also added the `--build` option for the docker-compose, otherwise it doesn't try to re-build the images even if the Dockerfile changed and added a few more latency percentiles in the K6 output.