### PR TITLE
Constant & common subgraph delay

### DIFF
--- a/federation-v1/subgraphs/accounts/subgraph.rs
+++ b/federation-v1/subgraphs/accounts/subgraph.rs
@@ -98,20 +98,10 @@ impl Query {
 }
 
 async fn delay_middleware<B>(req: Request<B>, next: Next<B>) -> Result<Response, StatusCode> {
-    let delay_range = var("SUBGRAPH_DELAY_MS").ok().and_then(|range| {
-        let mut parts = range.split("~");
-        let min: Option<i32> = parts.next().and_then(|s| s.parse().ok());
-        let max: Option<i32> = parts.next().and_then(|s| s.parse().ok());
+    let delay_ms: Option<u64> = std::env::var("SUBGRAPH_DELAY_MS").ok().and_then(|s| s.parse().ok()).filter(|d| *d != 0);;
 
-        match (min, max) {
-            (Some(m1), Some(m2)) => Some((m1, m2)),
-            _ => None,
-        }
-    });
-
-    if let Some(range) = delay_range {
-        let delay = rand::thread_rng().gen_range(range.0..range.1);
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay as u64)).await;
+    if let Some(delay_ms) = delay_ms {
+        tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
     }
 
     Ok(next.run(req).await)

--- a/federation-v1/subgraphs/docker-compose.subgraphs.yaml
+++ b/federation-v1/subgraphs/docker-compose.subgraphs.yaml
@@ -10,7 +10,7 @@ services:
       - "0.0.0.0:4001:4001"
     environment:
       PORT: 4001
-      SUBGRAPH_DELAY_MS: ${ACCOUNTS_SUBGRAPH_DELAY_MS}
+      SUBGRAPH_DELAY_MS: ${SUBGRAPH_DELAY_MS}
     healthcheck:
         test: ["CMD", "/usr/lib/apt/apt-helper", "download-file", "http://0.0.0.0:4001/graphql", "temp"]
         interval: 3s
@@ -25,7 +25,7 @@ services:
       - 4002:4002
     environment:
       PORT: 4002
-      SUBGRAPH_DELAY_MS: ${INVENTORY_SUBGRAPH_DELAY_MS}
+      SUBGRAPH_DELAY_MS: ${SUBGRAPH_DELAY_MS}
     healthcheck:
         test: ["CMD", "/usr/lib/apt/apt-helper", "download-file", "http://0.0.0.0:4002/graphql", "temp"]
         interval: 3s
@@ -40,7 +40,7 @@ services:
       - "0.0.0.0:4003:4003"
     environment:
       PORT: 4003
-      SUBGRAPH_DELAY_MS: ${PRODUCTS_SUBGRAPH_DELAY_MS}
+      SUBGRAPH_DELAY_MS: ${SUBGRAPH_DELAY_MS}
     healthcheck:
       test: ["CMD", "/usr/lib/apt/apt-helper", "download-file", "http://0.0.0.0:4003/graphql", "temp"]
       interval: 3s
@@ -55,7 +55,7 @@ services:
       - 4004:4004
     environment:
       PORT: 4004
-      SUBGRAPH_DELAY_MS: ${REVIEWS_SUBGRAPH_DELAY_MS}
+      SUBGRAPH_DELAY_MS: ${SUBGRAPH_DELAY_MS}
     healthcheck:
         test: ["CMD", "/usr/lib/apt/apt-helper", "download-file", "http://0.0.0.0:4004/graphql", "temp"]
         interval: 3s

--- a/federation-v1/subgraphs/products/subgraph.rs
+++ b/federation-v1/subgraphs/products/subgraph.rs
@@ -111,20 +111,10 @@ impl Query {
 }
 
 async fn delay_middleware<B>(req: Request<B>, next: Next<B>) -> Result<Response, StatusCode> {
-    let delay_range = var("SUBGRAPH_DELAY_MS").ok().and_then(|range| {
-        let mut parts = range.split("~");
-        let min: Option<i32> = parts.next().and_then(|s| s.parse().ok());
-        let max: Option<i32> = parts.next().and_then(|s| s.parse().ok());
+    let delay_ms: Option<u64> = std::env::var("SUBGRAPH_DELAY_MS").ok().and_then(|s| s.parse().ok()).filter(|d| *d != 0);;
 
-        match (min, max) {
-            (Some(m1), Some(m2)) => Some((m1, m2)),
-            _ => None,
-        }
-    });
-
-    if let Some(range) = delay_range {
-        let delay = rand::thread_rng().gen_range(range.0..range.1);
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay as u64)).await;
+    if let Some(delay_ms) = delay_ms {
+        tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
     }
 
     Ok(next.run(req).await)

--- a/federation-v1/subgraphs/reviews/subgraph.rs
+++ b/federation-v1/subgraphs/reviews/subgraph.rs
@@ -184,20 +184,10 @@ impl Query {
 }
 
 async fn delay_middleware<B>(req: Request<B>, next: Next<B>) -> Result<Response, StatusCode> {
-    let delay_range = var("SUBGRAPH_DELAY_MS").ok().and_then(|range| {
-        let mut parts = range.split("~");
-        let min: Option<i32> = parts.next().and_then(|s| s.parse().ok());
-        let max: Option<i32> = parts.next().and_then(|s| s.parse().ok());
+    let delay_ms: Option<u64> = std::env::var("SUBGRAPH_DELAY_MS").ok().and_then(|s| s.parse().ok()).filter(|d| *d != 0);;
 
-        match (min, max) {
-            (Some(m1), Some(m2)) => Some((m1, m2)),
-            _ => None,
-        }
-    });
-
-    if let Some(range) = delay_range {
-        let delay = rand::thread_rng().gen_range(range.0..range.1);
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay as u64)).await;
+    if let Some(delay_ms) = delay_ms {
+        tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
     }
 
     Ok(next.run(req).await)


### PR DESCRIPTION
Subgraph delay are useful to imitate network latency. Having different latencies for the subgraph isn't that useful IMHO. Having variable latencies makes the benchmark less consistent. It's useful to test how a system behaves, but I wouldn't recommend it when comparing systems.