### PR TITLE
Use --build for docker compose

### DIFF
--- a/federation-v1/scenarios/constant-vus-over-time/run.sh
+++ b/federation-v1/scenarios/constant-vus-over-time/run.sh
@@ -27,7 +27,7 @@ on_error(){
  
 trap 'on_error' ERR
 
-docker compose $COMPOSE_FLAGS up -d --wait --force-recreate
+docker compose $COMPOSE_FLAGS up -d --wait --force-recreate --build
 
 if [[ -z "${CI}" ]]; then
     trap "docker compose $COMPOSE_FLAGS down && exit 0" INT

--- a/federation-v1/scenarios/ramping-vus/run.sh
+++ b/federation-v1/scenarios/ramping-vus/run.sh
@@ -27,7 +27,7 @@ on_error(){
  
 trap 'on_error' ERR
 
-docker compose $COMPOSE_FLAGS up -d --wait --force-recreate
+docker compose $COMPOSE_FLAGS up -d --wait --force-recreate --build
 
 if [[ -z "${CI}" ]]; then
     trap "docker compose $COMPOSE_FLAGS down && exit 0" INT


### PR DESCRIPTION
Without this option, docker won't rebuild the image, only re-create containers, even if files have changed. It's a subtle behavior that hides problem IMHO. For example the changes I just made for subgraph dealy weren't taken into account when running the benchmarks because of this.

So I strongly recommend using this feature.