### PR TITLE
Set CPU limit to 0.25 for the CI

### DIFF
--- a/.github/workflows/federation-v1.workflow.yaml
+++ b/.github/workflows/federation-v1.workflow.yaml
@@ -43,7 +43,7 @@ jobs:
       scenarioDir: constant-vus-over-time
       scenarioName: constant-vus-over-time
       runner: ${{ needs.decide-runner.outputs.runner }}
-      cpuLimit: ${{ github.event_name == 'pull_request' && '1' || '2' }}
+      cpuLimit: ${{ github.event_name == 'pull_request' && '0.25' || '0.25' }}
       memoryLimit: ${{ github.event_name == 'pull_request' && '2gb' || '4gb' }}
 
   constant-vus-over-time-report:
@@ -81,7 +81,7 @@ jobs:
       scenarioDir: constant-vus-over-time
       scenarioName: constant-vus-subgraphs-delay
       runner: ${{ needs.decide-runner.outputs.runner }}
-      cpuLimit: ${{ github.event_name == 'pull_request' && '1' || '2' }}
+      cpuLimit: ${{ github.event_name == 'pull_request' && '0.25' || '0.25' }}
       memoryLimit: ${{ github.event_name == 'pull_request' && '2gb' || '4gb' }}
       subgraphDelayRange: "40~150"
 
@@ -120,7 +120,7 @@ jobs:
       scenarioDir: constant-vus-over-time
       scenarioName: constant-vus-subgraphs-delay-resources
       runner: ${{ needs.decide-runner.outputs.runner }}
-      cpuLimit: ${{ github.event_name == 'pull_request' && '2' || '4' }}
+      cpuLimit: ${{ github.event_name == 'pull_request' && '0.25' || '0.25' }}
       memoryLimit: ${{ github.event_name == 'pull_request' && '2gb' || '8gb' }}
       subgraphDelayRange: "40~150"
 
@@ -159,7 +159,7 @@ jobs:
       scenarioDir: ramping-vus
       scenarioName: ramping-vus
       runner: ${{ needs.decide-runner.outputs.runner }}
-      cpuLimit: ${{ github.event_name == 'pull_request' && '2' || '4' }}
+      cpuLimit: ${{ github.event_name == 'pull_request' && '0.25' || '0.25' }}
       memoryLimit: ${{ github.event_name == 'pull_request' && '2gb' || '8gb' }}
 
   ramping-vus-report:


### PR DESCRIPTION
Current benchmarks consume a lot of CPUs mainly due to the checks done in K6 script. For a single CPU core allocated to Grafbase, I need roughly 7 others for K6 and 2-3 others for the subgraphs. So results are inaccurate as the machine is saturated. Cosmo is also likely impacted.

On my machine setting the limit to 0.25 reduced total CPU usage to roughly 3 cores which would fit inside the CI machine.